### PR TITLE
Fix db_session annotation

### DIFF
--- a/backend/tests/integration/test_etl_workflow.py
+++ b/backend/tests/integration/test_etl_workflow.py
@@ -1,7 +1,8 @@
 import pytest
 import asyncio
 import uuid
-from httpx import AsyncClient # TestClient uses AsyncClient
+from httpx import AsyncClient  # TestClient uses AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import status # For status codes
 
 from app.schemas.etl import ProcessingStatus, ProcessingType
@@ -11,8 +12,8 @@ from app.db.models import DataFile as DBDataFile, ProcessingResult as DBProcessi
 pytestmark = pytest.mark.asyncio
 
 async def test_upload_trigger_etl_and_get_result(
-    test_client: AsyncClient, 
-    db_session: AsyncClient, # db_session is actually an AsyncSession, typo in description
+    test_client: AsyncClient,
+    db_session: AsyncSession,
     sample_csv_file: tuple[str, bytes]
 ):
     """


### PR DESCRIPTION
## Summary
- import `AsyncSession` for integration tests
- use `AsyncSession` for `db_session` fixture in ETL workflow test

## Testing
- `pytest backend/tests/integration/test_etl_workflow.py::test_upload_trigger_etl_and_get_result -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6846f2b678008324a7b8e29541ab9286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated type hints for improved test code clarity. No changes to test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->